### PR TITLE
Use user preference tool in crew

### DIFF
--- a/src/auto_content_creator/config/agents.yaml
+++ b/src/auto_content_creator/config/agents.yaml
@@ -13,6 +13,8 @@ news_copywriter:
   goal: Rewrite provided news articles into high-engagement Instagram hooks and captions, using the given style examples as writing references.
   backstory: >
     Social content specialist skilled at transforming news into viral, on-brand IG content while matching target writing styles.
+  tools:
+    - UserPreferenceTool
   llm: openrouter/nvidia/llama-3.3-nemotron-super-49b-v1:free
 
 designer_agent:

--- a/src/auto_content_creator/crew.py
+++ b/src/auto_content_creator/crew.py
@@ -3,6 +3,7 @@ import yaml
 import json
 from crewai import Agent, Task, Crew, Process
 from crewai_tools import SerperDevTool, ScrapeWebsiteTool
+from auto_content_creator.tools.user_preference_tool import UserPreferenceTool
 
 def load_yaml(file_path):
     here = os.path.dirname(__file__)
@@ -26,6 +27,7 @@ def make_agents():
         role=agents_config["news_copywriter"]["role"],
         goal=agents_config["news_copywriter"]["goal"],
         backstory=agents_config["news_copywriter"]["backstory"],
+        tools=[UserPreferenceTool()],
         llm=agents_config["news_copywriter"]["llm"],
         verbose=True
     )

--- a/src/auto_content_creator/tools/__init__.py
+++ b/src/auto_content_creator/tools/__init__.py
@@ -1,0 +1,4 @@
+
+from .user_preference_tool import UserPreferenceTool
+
+__all__ = ["UserPreferenceTool"]

--- a/src/auto_content_creator/tools/user_preference_tool.py
+++ b/src/auto_content_creator/tools/user_preference_tool.py
@@ -12,7 +12,7 @@ class UserPreferenceTool(BaseTool):
         # Construct the path relative to this file's location
         here = os.path.dirname(__file__)
         # Go up two levels to the project root, then into the knowledge folder
-        knowledge_path = os.path.join(here, "..", "..", "knowledge", "user_preference.txt")
+        knowledge_path = os.path.join(here, "..", "..", "..", "knowledge", "user_preference.txt")
         
         try:
             with open(knowledge_path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- export `UserPreferenceTool`
- point `UserPreferenceTool` to the correct knowledge path
- register `UserPreferenceTool` on the copywriter agent
- document the tool in the agents config

## Testing
- `python -m compileall -q src/auto_content_creator`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684401d51644832e8066dc74ce0b5da2