### PR TITLE
Fix JSON output for crew tasks

### DIFF
--- a/src/auto_content_creator/crew.py
+++ b/src/auto_content_creator/crew.py
@@ -66,15 +66,16 @@ def make_tasks(news_reporter, news_copywriter, designer_agent, field, website, s
         description=rewrite_article_desc,
         expected_output=tasks_config["rewrite_article"]["expected_output"],
         agent=news_copywriter,
-        context=[scrape_article_content]
+        context=[scrape_article_content],
+        output_json=True
     )
 
     generate_image_prompt = Task(
         description=tasks_config["generate_image_prompt"]["description"],
         expected_output=tasks_config["generate_image_prompt"]["expected_output"],
         agent=designer_agent,
-        context=[rewrite_article]
-        # REMOVED output_json=True from here
+        context=[rewrite_article],
+        output_json=True
     )
 
     return [find_article_urls, scrape_article_content, rewrite_article, generate_image_prompt]


### PR DESCRIPTION
## Summary
- enable JSON output for rewrite_article and generate_image_prompt tasks

## Testing
- `python -m py_compile src/auto_content_creator/crew.py`

------
https://chatgpt.com/codex/tasks/task_e_684401ea1be8832eb144dfadbf05cef5